### PR TITLE
Changed case f in Mesh3D.loadObj to deal with index issue

### DIFF
--- a/src/renderer/Mesh3D.cs
+++ b/src/renderer/Mesh3D.cs
@@ -187,17 +187,38 @@ public class Mesh3D
                             var faceIndices = faceToken.Split('/')
                                 .Select(x => string.IsNullOrEmpty(x) ? 0 : uint.Parse(x))
                                 .ToArray();
-                            if (faceIndices.Length >= 1 && faceIndices[0] > 0)
+
+                            if (faceIndices.Length < 3)
                             {
-                                indices.Add(faceIndices[0] - 1);
+                                /// Face token doesn't contain enough indices, we thus need to skip
+                                continue;
                             }
+                            if (faceIndices.Length > 3)
+                            {
+                                /// Face token contains extra indices, only use the first three (working on triangles, OpenGl4)
+                                faceIndices = faceIndices.Take(3).ToArray();
+                            }
+                            var vertexIndex = faceIndices[0] - 1;
+                            var normalIndex = faceIndices[2] - 1;
+                            if (vertexIndex < 0 || vertexIndex >= vertices.Count ||
+                                normalIndex < 0 || normalIndex >= normals.Count)
+                            {
+                                /// Indices are out of range, skip the face
+                                continue;
+                            }
+                            indices.Add((uint)vertexIndex);
+                            indices.Add((uint)normalIndex);
+
+                            /// Add indices for the other primitive types as well
                             if (faceIndices.Length >= 2 && faceIndices[1] > 0)
                             {
-                                // We don't do anything with texture coordinates for now
-                            }
-                            if (faceIndices.Length >= 3 && faceIndices[2] > 0)
-                            {
-                                indices.Add(faceIndices[2] - 1);
+                                var texCoordIndex = faceIndices[1] - 1;
+                                if (texCoordIndex < 0 || texCoordIndex >= texCoords.Count)
+                                {
+                                    /// Texture coordinate index is out of range, skip it
+                                    continue;
+                                }
+                                indices.Add((uint)texCoordIndex);
                             }
                         }
                         break;


### PR DESCRIPTION
First time creating pull req, please bear with me!
[Issue](https://github.com/William-McGonagle/sledge/issues/4): 
Changed the code in case 'f' of Mesh3D.loadObj. Made sure that indices are only added with a valid f command length (ie 3 or 4). For those with indices with 4 (quad face), changed it back to 3, given that we are working with OpenGl4 which uses triangles. Meanwhile added changes for the texture coordinate indices as well. 
Note: May be important to only use Obj file whose 'f' tag only uses 3 indices given the use of OpenGl4. 